### PR TITLE
use equals sign for setenv function

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,5 @@
 if test -z "$SSH_ENV"
-    setenv SSH_ENV $HOME/.ssh/environment
+    setenv SSH_ENV=$HOME/.ssh/environment
 end
 
 if not __ssh_agent_is_started

--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,5 @@
 if test -z "$SSH_ENV"
-    setenv SSH_ENV=$HOME/.ssh/environment
+    set -xg SSH_ENV $HOME/.ssh/environment
 end
 
 if not __ssh_agent_is_started


### PR DESCRIPTION
Fish version 2.5.0-235-g84cf391 changes `setenv` function implementation.
Using equal sign to assign SSH_ENV variable fixes error caused by the change.