### PR TITLE
Use ssh-add to check if agent is started as ps does not always work

### DIFF
--- a/functions/__ssh_agent_is_started.fish
+++ b/functions/__ssh_agent_is_started.fish
@@ -1,5 +1,5 @@
 function __ssh_agent_is_started -d "check if ssh agent is already started"
-  	if begin; test -f $SSH_ENV; and test -z "$SSH_AGENT_PID"; end
+	if begin; test -f $SSH_ENV; and test -z "$SSH_AGENT_PID"; end
 		source $SSH_ENV > /dev/null
 	end
 
@@ -7,8 +7,8 @@ function __ssh_agent_is_started -d "check if ssh agent is already started"
 		return 1
 	end
 
-	ssh-add -l > /dev/null
-	if [ $status -eq 2 ]
-	    return 1
+	ssh-add -l > /dev/null 2>&1
+	if test $status -eq 2
+		return 1
 	end
 end

--- a/functions/__ssh_agent_is_started.fish
+++ b/functions/__ssh_agent_is_started.fish
@@ -7,6 +7,8 @@ function __ssh_agent_is_started -d "check if ssh agent is already started"
 		return 1
 	end
 
-	ps -ef | grep $SSH_AGENT_PID | grep -v grep | grep -q ssh-agent
-	return $status
+	ssh-add -l > /dev/null
+	if [ $status -eq 2 ]
+	    return 1
+	end
 end


### PR DESCRIPTION
On latest Android for example detached daemons do not show up with ps. Some kind of security feature. Also using ssh-add is accurate, ps could still be wrong.