### PR TITLE
Do not treat ssh-agent as not running simply from `SSH_AGENT_PID`

### DIFF
--- a/functions/__ssh_agent_is_started.fish
+++ b/functions/__ssh_agent_is_started.fish
@@ -3,7 +3,7 @@ function __ssh_agent_is_started -d "check if ssh agent is already started"
 		source $SSH_ENV > /dev/null
 	end
 
-	if test -z "$SSH_AGENT_PID"
+	if begin; test -z "$SSH_AGENT_PID"; and test -z "$SSH_CONNECTION"; end
 		return 1
 	end
 


### PR DESCRIPTION
I use [home-manager](https://github.com/nix-community/home-manager) to maintain my dotfiles on all machines I access, and I ran into a problem with this addon for fish. It spawns a `ssh-agent` even remotely if `SSH_AGENT_PID` is not set. So I've extended it so the test reads if both `SSH_AGENT_PID` and `SSH_CONNECTION` is not set.