### PR TITLE
In an SSH session check forwarded agent first

### DIFF
--- a/functions/__ssh_agent_is_started.fish
+++ b/functions/__ssh_agent_is_started.fish
@@ -1,9 +1,18 @@
 function __ssh_agent_is_started -d "check if ssh agent is already started"
-	if begin; test -f $SSH_ENV; and test -z "$SSH_AGENT_PID"; end
+	if test -n "$SSH_CONNECTION"
+		# This is an SSH session
+		ssh-add -l > /dev/null 2>&1
+		if test $status -eq 0 -o $status -eq 1
+			# An SSH agent was forwarded
+			return 0
+		end
+	end
+
+	if begin; test -f "$SSH_ENV"; and test -z "$SSH_AGENT_PID"; end
 		source $SSH_ENV > /dev/null
 	end
 
-	if begin; test -z "$SSH_AGENT_PID"; and test -z "$SSH_CONNECTION"; end
+	if test -z "$SSH_AGENT_PID"
 		return 1
 	end
 


### PR DESCRIPTION
When in an SSH session, try to connect to a forwarded agent first. If that fails, only then check if an SSH agent is already running on the machine.

This fixes a situation where a .ssh/environment file left behind from a dead agent is checked first, ignoring the forwarded agent and starting a new agent on the machine.