### PR TITLE
Add configuration options for ssh-agent and automatic cleanup on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ fisher install danhper/fish-ssh-agent
 ### Manually
 
 Copy `functions` and `conf.d` to your `$__fish_config_dir` directory. That's all.
+
+## Configuration
+
+### Additional ssh-agent Parameters
+
+You can pass additional parameters to `ssh-agent` by setting the `SSH_AGENT_OPTS` environment variable. For example, to set a custom timeout:
+
+```fish
+set -gx SSH_AGENT_OPTS "-t 3600"
+```
+
+This will be passed to `ssh-agent` when it starts. The plugin will automatically use these options when starting a new agent.
+
+### Automatic Cleanup
+
+The plugin automatically stops the ssh-agent when you exit fish, but only if the agent was started by this plugin. If you're using an SSH forwarded agent (e.g., when SSHing into a remote machine), it will not be stopped on exit.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Copy `functions` and `conf.d` to your `$__fish_config_dir` directory. That's all
 You can pass additional parameters to `ssh-agent` by setting the `SSH_AGENT_OPTS` environment variable. For example, to set a custom timeout:
 
 ```fish
-set -gx SSH_AGENT_OPTS "-t 3600"
+set -gx SSH_AGENT_OPTS -t 3600
 ```
 
-This will be passed to `ssh-agent` when it starts. The plugin will automatically use these options when starting a new agent.
+**Note:** Set `SSH_AGENT_OPTS` as a list (without quotes around multiple arguments) for best results. The plugin will automatically use these options when starting a new agent.
 
 ### Automatic Cleanup
 

--- a/conf.d/fish-ssh-agent.fish
+++ b/conf.d/fish-ssh-agent.fish
@@ -5,3 +5,7 @@ end
 if not __ssh_agent_is_started
     __ssh_agent_start
 end
+
+function __on_fish_exit --on-event fish_exit
+    __ssh_agent_stop
+end

--- a/conf.d/fish-ssh-agent.fish
+++ b/conf.d/fish-ssh-agent.fish
@@ -2,8 +2,14 @@ if test -z "$SSH_ENV"
     set -xg SSH_ENV $HOME/.ssh/environment
 end
 
-if not __ssh_agent_is_started
-    __ssh_agent_start
+function __fish_ssh_agent_init --on-event fish_prompt
+    if not set -q __fish_ssh_agent_initialized
+        if not __ssh_agent_is_started
+            __ssh_agent_start
+        end
+        set -g __fish_ssh_agent_initialized 1
+        functions -e __fish_ssh_agent_init
+    end
 end
 
 function __on_fish_exit --on-event fish_exit

--- a/functions/__ssh_agent_is_started.fish
+++ b/functions/__ssh_agent_is_started.fish
@@ -3,7 +3,8 @@ function __ssh_agent_is_started -d "check if ssh agent is already started"
 		# This is an SSH session
 		ssh-add -l > /dev/null 2>&1
 		if test $status -eq 0 -o $status -eq 1
-			# An SSH agent was forwarded
+			# An SSH agent was forwarded - don't mark as started by us
+			set -e __fish_ssh_agent_started
 			return 0
 		end
 	end

--- a/functions/__ssh_agent_start.fish
+++ b/functions/__ssh_agent_start.fish
@@ -1,10 +1,15 @@
 function __ssh_agent_start -d "start a new ssh agent"
-  set -l agent_opts ""
   if test -n "$SSH_AGENT_OPTS"
-    set agent_opts $SSH_AGENT_OPTS
+    set -l opts
+    if test (count $SSH_AGENT_OPTS) -eq 1
+      set opts (string split " " -- $SSH_AGENT_OPTS)
+    else
+      set opts $SSH_AGENT_OPTS
+    end
+    ssh-agent -c $opts | sed 's/^echo/#echo/' > $SSH_ENV
+  else
+    ssh-agent -c | sed 's/^echo/#echo/' > $SSH_ENV
   end
-
-  ssh-agent -c $agent_opts | sed 's/^echo/#echo/' > $SSH_ENV
   chmod 600 $SSH_ENV
   source $SSH_ENV > /dev/null
 

--- a/functions/__ssh_agent_start.fish
+++ b/functions/__ssh_agent_start.fish
@@ -1,5 +1,12 @@
 function __ssh_agent_start -d "start a new ssh agent"
-  ssh-agent -c | sed 's/^echo/#echo/' > $SSH_ENV
+  set -l agent_opts ""
+  if test -n "$SSH_AGENT_OPTS"
+    set agent_opts $SSH_AGENT_OPTS
+  end
+
+  ssh-agent -c $agent_opts | sed 's/^echo/#echo/' > $SSH_ENV
   chmod 600 $SSH_ENV
   source $SSH_ENV > /dev/null
+
+  set -gx __fish_ssh_agent_started 1
 end

--- a/functions/__ssh_agent_stop.fish
+++ b/functions/__ssh_agent_stop.fish
@@ -1,0 +1,10 @@
+function __ssh_agent_stop -d "stop ssh agent if it was started by this plugin"
+	if test -n "$__fish_ssh_agent_started" -a -n "$SSH_AGENT_PID"
+		if kill -0 $SSH_AGENT_PID 2>/dev/null
+			kill $SSH_AGENT_PID
+		end
+		set -e __fish_ssh_agent_started
+		set -e SSH_AGENT_PID
+		set -e SSH_AUTH_SOCK
+	end
+end


### PR DESCRIPTION
- Introduced SSH_AGENT_OPTS to allow users to pass additional parameters to ssh-agent.
- Implemented automatic stopping of ssh-agent on fish exit if started by the plugin.

